### PR TITLE
Migrate to sha256

### DIFF
--- a/serve.rb
+++ b/serve.rb
@@ -3,7 +3,7 @@ require "formula"
 class Serve < Formula
   homepage "https://github.com/kidoman/serve"
   url "https://github.com/kidoman/serve/archive/v0.2.3.tar.gz"
-  sha1 "cb4bc4a7cb7a321e104bcc76aa31390205b39752"
+  sha256 "f80fafcee55f168a6bbd052e2870e208f7a193233de503fed739d5a6529853ac"
 
   head "https://github.com/kidoman/serve.git"
 


### PR DESCRIPTION
Homebrew complains (rightfully so) about sha1.

```
[michaeldoyle-macbookpro ~]$ brew install kidoman/tools/serve
==> Tapping kidoman/tools
Cloning into '/Users/michaeldoyle/homebrew/Library/Taps/kidoman/homebrew-tools'...
remote: Counting objects: 4, done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 4 (delta 0), reused 2 (delta 0), pack-reused 0
Unpacking objects: 100% (4/4), done.
Error: Invalid formula: /Users/michaeldoyle/homebrew/Library/Taps/kidoman/homebrew-tools/serve.rb
Calling Formula.sha1 is disabled!
Use Formula.sha256 instead.
/Users/michaeldoyle/homebrew/Library/Taps/kidoman/homebrew-tools/serve.rb:6:in `<class:Serve>'
Please report this to the kidoman/tools tap!
Error: Cannot tap kidoman/tools: invalid syntax in tap!
```

This will update to sha256

```
[michaeldoyle-macbookpro ~]$ shasum -a 256 v0.2.3.tar.gz
f80fafcee55f168a6bbd052e2870e208f7a193233de503fed739d5a6529853ac  v0.2.3.tar.gz
```